### PR TITLE
v1.34

### DIFF
--- a/MAUCacheAdmin
+++ b/MAUCacheAdmin
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 #set -x
 
 TOOL_NAME="Microsoft AutoUpdate Cache Admin"
-TOOL_VERSION="1.32"
+TOOL_VERSION="1.34"
 
 ## Copyright (c) 2016 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.
@@ -25,7 +25,7 @@ MAUID_OFFICE2011="0409MSOF14"
 MAUID_LYNC2011="0409UCCP14"
 MAUID_SKYPE2016="0409MSFB16"
 CHANNEL_COLLATERAL_PROD="https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/OfficeMac/"
-SCRATCH_AREA="$TMPDIR""MAUCacheAdmin"
+SCRATCH_AREA="$TMPDIR""MAUCache"
 
 # Platform detection
 PLATFORM=$(uname -s)


### PR DESCRIPTION
Ubuntu has some conflicting default shell environment settings that cause MAUCacheAdmin to fail if the temporary directory name is the same as the tool name. Found by @ dustin on Slack.

I've also modified the shebang to use bash as you're currently using some functions that aren't  `/bin/sh` friendly. http://unix.stackexchange.com/a/5591

The workaround if you don't want to change the shebang would be to tell users to call with `bash MAUCacheAdmin` but IMO that's more of a support hassle than just modifying the shebang.

Tested changes with 10.12 and ubuntu 16.04.1. 
