### PR TITLE
Added basic systemd service for launching MAUCacheAdmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@
 Purpose: Downloads MAU collateral and packages from the Office CDN to a local web server</br>
 Usage: MAUCacheAdmin --CachePath:<path> [--CheckInterval:<minutes>] [--HTTPOnly] [--NoCollateral]</br>
 Example: MAUCacheAdmin --CachePath:/Volumes/web/MAU/cache --CheckInterval:60</br>
+
+## maucache.service
+
+A simple systemd server to launch MAUCacheAdmin at boot with a 15 minute interval and auto-restart upon a failure.
+
+This service was written and tested on Ubuntu 16.04 using Nginx. The MAUCacheAdmin script is assumed to be located in `/usr/local/`. Update these values accordingly.
+
+The `ExecStopPost` line has an optional mail command to notify an email address if the service stops. Remove this line if you do not wish to use this option.
+
+To use this service write the `maucache.service` file to `/lib/systemd/system/` and run the following commands:
+
+```
+sudo systemctl enable maucache.service
+sudo systemctl daemon-reload
+sudo systemctl start maucache.service
+sudo systemctl status maucache.service
+```

--- a/maucache.service
+++ b/maucache.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Microsoft AutoUpdate Cache Admin Runner
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c "/usr/local/MAUCacheAdmin --CachePath:/var/www/html --CheckInterval:15"
+ExecStopPost=/bin/sh -c 'echo "The MAUCacheAdmin service has stopped: Automatic restart in 5 minutes." | /usr/bin/mail -s "MAUCacheAdmin Stopped" -a "From: MAUCacheAdmin <admin@maucacheserver>" you@your.org'
+Restart=always
+RestartSec=300
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
systemd service that launches MAUCacheAdmin at boot and auto-restarts
if the service unexpectedly quits.
- Tested on Ubuntu 16.04
- Assumes MAUCacheAdmin is located in /usr/local/
- Assumes Nginx is running web service and uses default web directory of /var/www/html/
