### PR TITLE
Update PS Module to 1.0.1

### DIFF
--- a/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
+++ b/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
@@ -12,7 +12,7 @@
 RootModule = 'MAUCacheAdmin.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0'
+ModuleVersion = '1.0.1'
 
 # ID used to uniquely identify this module
 GUID = '41ac64b9-6f2c-46a2-9d55-e6fb6c3d75ad'

--- a/PSModule/MAUCacheAdmin/Public/Invoke-MAUCacheDownload.ps1
+++ b/PSModule/MAUCacheAdmin/Public/Invoke-MAUCacheDownload.ps1
@@ -68,12 +68,12 @@ function Invoke-MAUCacheDownload {
             $cacheIsValid = $false
         }
 
-        if ($targetCacheItem.Length -ne $dlJob.SizeBytes) {
+        if ($cacheIsValid -and $targetCacheItem.Length -ne $dlJob.SizeBytes) {
             Write-Warning "Package $($dlJob.Payload) exists in the cache but the file size does not match... Will redownload"
             $cacheIsValid = $false
         }
 
-        if ($CompareLastModified -and $cacheIsValid -and $targetCacheItem.LastWriteTimeUtc -ne $dlJob.LastModified) {
+        if ($cacheIsValid -and $CompareLastModified -and $targetCacheItem.LastWriteTimeUtc -ne $dlJob.LastModified) {
             Write-Warning "Package $($dlJob.Payload) exists in the cache but the Last Modified does not match... Will redownload"
             $cacheIsValid = $false
         }


### PR DESCRIPTION
Fixes output of `Invoke-MAUCacheDownload` when the files don't exist in the cache path.

Previous to this it would always warn with `"Package {filename} exists in the cache but the file size does not match... Will redownload"` when the file was not in the cache.