### PR TITLE
Update PS Module to 1.0.2

### DIFF
--- a/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
+++ b/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
@@ -12,7 +12,7 @@
 RootModule = 'MAUCacheAdmin.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.0.2'
 
 # ID used to uniquely identify this module
 GUID = '41ac64b9-6f2c-46a2-9d55-e6fb6c3d75ad'

--- a/PSModule/MAUCacheAdmin/Private/Get-MAUApp.ps1
+++ b/PSModule/MAUCacheAdmin/Private/Get-MAUApp.ps1
@@ -60,7 +60,7 @@ function Get-MAUApp {
 
     # Process App History XML
     Write-Verbose "$logPrefix Getting App History Packages"
-    [string[]]$historicAppVersions = Get-PlistObjectFromURI -URI $app.CollateralURIs.HistoryXML -HttpClient $HttpClient
+    [string[]]$historicAppVersions = Get-PlistObjectFromURI -URI $app.CollateralURIs.HistoryXML -HttpClient $HttpClient -Optional
     if ($null -eq $historicAppVersions) {
         # Leave HistoricPackages empty ( -history.xml files are optional and only on certain apps )
         Write-Verbose "$logPrefix No App history XML found"


### PR DESCRIPTION
The MAU CDN is now returning 404's for the -history.xml files that do not exist. When the module was written the CDN would return 400 for files/paths that were not valid including the historic manifests on apps that don't have them.
At the time the error handling was just looking for 400 BadRequests and now this is causing exceptions when running Get-MAUApps.

This has been reworked to ignore all HttpRequestException's when trying to get the -history.xml files, all other plist/xml requests will now bubble up the exception regardless of the response code.