### PR TITLE
Add support for new teams

### DIFF
--- a/MAUCacheAdmin
+++ b/MAUCacheAdmin
@@ -317,9 +317,9 @@ GetAppNameFromMAUID () {
 								;;
 		$MAUID_EDGE)			APPNAME="Edge"
 								;;
-		$MAUID_TEAMS)			APPNAME="Teams"
+		$MAUID_TEAMS)			APPNAME="Teams 1.0 classic"
 								;;
-		$MAUID_TEAMS2)			APPNAME="Teams 2.x"
+		$MAUID_TEAMS2)			APPNAME="Teams 2.1"
 								;;
 		$MAUID_OFFICELICHELPER)	APPNAME="Office Licensing Helper"
 								;;

--- a/MAUCacheAdmin
+++ b/MAUCacheAdmin
@@ -2,7 +2,7 @@
 #set -x
 
 TOOL_NAME="Microsoft AutoUpdate Cache Admin"
-TOOL_VERSION="3.6"
+TOOL_VERSION="3.7"
 
 ## Copyright (c) 2023 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.
@@ -54,6 +54,7 @@ MAUID_ONEDRIVE="0409ONDR18"
 MAUID_DEFENDER="0409WDAV00"
 MAUID_EDGE="0409EDGE01"
 MAUID_TEAMS="0409TEAMS10"
+MAUID_TEAMS2="0409TEAMS21"
 MAUID_OFFICELICHELPER="0409OLIC02"
 CHANNEL_COLLATERAL_PROD="https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/"
 CHANNEL_COLLATERAL_INSIDERSLOW="https://officecdnmac.microsoft.com/pr/1ac37578-5a24-40fb-892e-b89d85b6dfaa/MacAutoupdate/"
@@ -153,7 +154,8 @@ BuildApplicationArray () {
 	MAUAPP[15]="$MAUID_DEFENDER"
 	MAUAPP[16]="$MAUID_EDGE"
 	MAUAPP[17]="$MAUID_TEAMS"
-	MAUAPP[18]="$MAUID_OFFICELICHELPER"
+	MAUAPP[18]="$MAUID_TEAMS2"
+	MAUAPP[19]="$MAUID_OFFICELICHELPER"
 }
 
 BuildCollateralArray () {
@@ -176,7 +178,8 @@ BuildCollateralArray () {
 	DOWNLOADARRAY[15]="$1"$MAUID_DEFENDER
 	DOWNLOADARRAY[16]="$1"$MAUID_EDGE
 	DOWNLOADARRAY[17]="$1"$MAUID_TEAMS
-	DOWNLOADARRAY[18]="$1"$MAUID_OFFICELICHELPER
+	DOWNLOADARRAY[18]="$1"$MAUID_TEAMS2
+	DOWNLOADARRAY[19]="$1"$MAUID_OFFICELICHELPER
 }
 
 DownloadCollateralFiles () {
@@ -315,6 +318,8 @@ GetAppNameFromMAUID () {
 		$MAUID_EDGE)			APPNAME="Edge"
 								;;
 		$MAUID_TEAMS)			APPNAME="Teams"
+								;;
+		$MAUID_TEAMS2)			APPNAME="Teams 2.x"
 								;;
 		$MAUID_OFFICELICHELPER)	APPNAME="Office Licensing Helper"
 								;;

--- a/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
+++ b/PSModule/MAUCacheAdmin/MAUCacheAdmin.psd1
@@ -12,7 +12,7 @@
 RootModule = 'MAUCacheAdmin.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.2'
+ModuleVersion = '1.0.3'
 
 # ID used to uniquely identify this module
 GUID = '41ac64b9-6f2c-46a2-9d55-e6fb6c3d75ad'

--- a/PSModule/MAUCacheAdmin/Public/Get-MAUApps.ps1
+++ b/PSModule/MAUCacheAdmin/Public/Get-MAUApps.ps1
@@ -41,6 +41,7 @@ function Get-MAUApps {
         [PSCustomObject]@{AppID = "0409WDAV00";     AppName = "Defender ATP"}
         [PSCustomObject]@{AppID = "0409EDGE01";     AppName = "Edge"}
         [PSCustomObject]@{AppID = "0409TEAMS10";    AppName = "Teams"}
+        [PSCustomObject]@{AppID = "0409TEAMS21";    AppName = "Teams 2.x"}
         [PSCustomObject]@{AppID = "0409OLIC02";     AppName = "Office Licensing Helper"}
     )
 

--- a/PSModule/MAUCacheAdmin/Public/Get-MAUApps.ps1
+++ b/PSModule/MAUCacheAdmin/Public/Get-MAUApps.ps1
@@ -40,8 +40,8 @@ function Get-MAUApps {
         [PSCustomObject]@{AppID = "0409ONDR18";     AppName = "OneDrive"}
         [PSCustomObject]@{AppID = "0409WDAV00";     AppName = "Defender ATP"}
         [PSCustomObject]@{AppID = "0409EDGE01";     AppName = "Edge"}
-        [PSCustomObject]@{AppID = "0409TEAMS10";    AppName = "Teams"}
-        [PSCustomObject]@{AppID = "0409TEAMS21";    AppName = "Teams 2.x"}
+        [PSCustomObject]@{AppID = "0409TEAMS10";    AppName = "Teams 1.0 classic"}
+        [PSCustomObject]@{AppID = "0409TEAMS21";    AppName = "Teams 2.1"}
         [PSCustomObject]@{AppID = "0409OLIC02";     AppName = "Office Licensing Helper"}
     )
 


### PR DESCRIPTION
Updates PS Module and MAUCacheAdmin Bash script with the new Teams AppID `0409TEAMS21`.

I used the AppName of `Teams 2.x` to match the convention of `MAU 4.x`, but I'm happy to change this to something more appropriate.

Addresses #44 