### PR TITLE
Deprecation of Microsoft Teams Classic

### DIFF
--- a/MAUCacheAdmin
+++ b/MAUCacheAdmin
@@ -2,7 +2,7 @@
 #set -x
 
 TOOL_NAME="Microsoft AutoUpdate Cache Admin"
-TOOL_VERSION="3.7"
+TOOL_VERSION="3.8"
 
 ## Copyright (c) 2023 Microsoft Corp. All rights reserved.
 ## Scripts are not supported under any Microsoft standard support program or service. The scripts are provided AS IS without warranty of any kind.
@@ -53,7 +53,6 @@ MAUID_REMOTEDESKTOP10="0409MSRD10"
 MAUID_ONEDRIVE="0409ONDR18"
 MAUID_DEFENDER="0409WDAV00"
 MAUID_EDGE="0409EDGE01"
-MAUID_TEAMS="0409TEAMS10"
 MAUID_TEAMS2="0409TEAMS21"
 MAUID_OFFICELICHELPER="0409OLIC02"
 CHANNEL_COLLATERAL_PROD="https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/"
@@ -153,9 +152,8 @@ BuildApplicationArray () {
 	MAUAPP[14]="$MAUID_ONEDRIVE"
 	MAUAPP[15]="$MAUID_DEFENDER"
 	MAUAPP[16]="$MAUID_EDGE"
-	MAUAPP[17]="$MAUID_TEAMS"
-	MAUAPP[18]="$MAUID_TEAMS2"
-	MAUAPP[19]="$MAUID_OFFICELICHELPER"
+	MAUAPP[17]="$MAUID_TEAMS2"
+	MAUAPP[18]="$MAUID_OFFICELICHELPER"
 }
 
 BuildCollateralArray () {
@@ -177,9 +175,8 @@ BuildCollateralArray () {
 	DOWNLOADARRAY[14]="$1"$MAUID_ONEDRIVE
 	DOWNLOADARRAY[15]="$1"$MAUID_DEFENDER
 	DOWNLOADARRAY[16]="$1"$MAUID_EDGE
-	DOWNLOADARRAY[17]="$1"$MAUID_TEAMS
-	DOWNLOADARRAY[18]="$1"$MAUID_TEAMS2
-	DOWNLOADARRAY[19]="$1"$MAUID_OFFICELICHELPER
+	DOWNLOADARRAY[17]="$1"$MAUID_TEAMS2
+	DOWNLOADARRAY[18]="$1"$MAUID_OFFICELICHELPER
 }
 
 DownloadCollateralFiles () {
@@ -316,8 +313,6 @@ GetAppNameFromMAUID () {
 		$MAUID_DEFENDER)		APPNAME="Defender ATP"
 								;;
 		$MAUID_EDGE)			APPNAME="Edge"
-								;;
-		$MAUID_TEAMS)			APPNAME="Teams 1.0 classic"
 								;;
 		$MAUID_TEAMS2)			APPNAME="Teams 2.1"
 								;;


### PR DESCRIPTION
Due to the recent deprecation of Microsoft Teams Classic and the renaming of the work or school version back to "Microsoft Teams," the script encountered an issue where both packages were named "MicrosoftTeams.pkg." This caused each definition to appear corrupted, leading to the removal of either the older or newer version and triggering a constant redownload of the Microsoft Teams packages.

Since the Classic version is no longer in use, I decided to remove all references to Microsoft Teams Classic and reorganized the array numbering accordingly.

Version updated to 3.8.